### PR TITLE
Fixes #26

### DIFF
--- a/ybot.config
+++ b/ybot.config
@@ -66,7 +66,7 @@
             {history_command_limit_count, 1000},
 
             % plugins directory path
-            {plugins_path, "/home/user/Ybot/plugins/"}
+            {plugins_path, "plugins/"}
         ]
     }
 ].


### PR DESCRIPTION
Default plugin path in ybot.config is now relative to the project root.
