### PR TITLE
Fix ybot.config example

### DIFF
--- a/ybot.config
+++ b/ybot.config
@@ -117,11 +117,11 @@
             %
             % Notifications
             %
-            {notification, 
-            %    [ % {plugin name :: atom(), [transport list :: atom()], timeout_in_seconds :: integer()} 
+            {notification, [
+            %    % {plugin name :: atom(), [transport list :: atom()], timeout_in_seconds :: integer()} 
             %      {ackbar, [irc, twitter], 60}
-            %    ]
-            },
+            %    
+            ]},
 
             %
             % Ybot channels (write only transports)


### PR DESCRIPTION
The following error shows up if I try to run Ybot using the test.config example file:

```
{"could not start kernel pid",application_controller,"error in config file \"./ybot.config\" (124): syntax error before: '}'"}
```
